### PR TITLE
Add Edital list component

### DIFF
--- a/api/src/main/webapp/app/app.component.ts
+++ b/api/src/main/webapp/app/app.component.ts
@@ -3,6 +3,7 @@ import { RouterOutlet } from '@angular/router';
 
 @Component({
   selector: 'app-root',
+  standalone: true,
   imports: [RouterOutlet],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'

--- a/api/src/main/webapp/app/app.config.ts
+++ b/api/src/main/webapp/app/app.config.ts
@@ -1,8 +1,13 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
 
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes)]
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(routes),
+    provideHttpClient()
+  ]
 };

--- a/api/src/main/webapp/app/app.routes.ts
+++ b/api/src/main/webapp/app/app.routes.ts
@@ -1,3 +1,7 @@
 import { Routes } from '@angular/router';
+import { EditalListComponent } from './edital/edital-list.component';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: '', redirectTo: 'editais', pathMatch: 'full' },
+  { path: 'editais', component: EditalListComponent }
+];

--- a/api/src/main/webapp/app/edital/edital-list.component.html
+++ b/api/src/main/webapp/app/edital/edital-list.component.html
@@ -1,0 +1,21 @@
+<h2>Editais</h2>
+<table>
+  <thead>
+    <tr>
+      <th>Numero</th>
+      <th>Nome</th>
+      <th>Inscrição Início</th>
+      <th>Inscrição Fim</th>
+      <th>Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr *ngFor="let edital of editais">
+      <td>{{ edital.numero }}</td>
+      <td>{{ edital.nome }}</td>
+      <td>{{ edital.dtInscricaoIni }}</td>
+      <td>{{ edital.dtInscricaoFim }}</td>
+      <td>{{ edital.status }}</td>
+    </tr>
+  </tbody>
+</table>

--- a/api/src/main/webapp/app/edital/edital-list.component.scss
+++ b/api/src/main/webapp/app/edital/edital-list.component.scss
@@ -1,0 +1,9 @@
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th, td {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+}

--- a/api/src/main/webapp/app/edital/edital-list.component.ts
+++ b/api/src/main/webapp/app/edital/edital-list.component.ts
@@ -1,0 +1,23 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { EditalService } from '../services/edital.service';
+import { Edital } from '../models/edital';
+
+@Component({
+  selector: 'app-edital-list',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './edital-list.component.html',
+  styleUrl: './edital-list.component.scss'
+})
+export class EditalListComponent implements OnInit {
+  editais: Edital[] = [];
+
+  constructor(private editalService: EditalService) {}
+
+  ngOnInit(): void {
+    this.editalService.list().subscribe({
+      next: data => (this.editais = data)
+    });
+  }
+}

--- a/api/src/main/webapp/app/models/edital.ts
+++ b/api/src/main/webapp/app/models/edital.ts
@@ -1,0 +1,12 @@
+export interface Edital {
+  id?: number;
+  numero: string;
+  nome: string;
+  dtInscricaoIni: string;
+  dtInscricaoFim: string;
+  linkConcurso: string;
+  status: string;
+  dtCadastro: string;
+  concursoHtml: string;
+  resultadoHomologado: string;
+}

--- a/api/src/main/webapp/app/services/edital.service.ts
+++ b/api/src/main/webapp/app/services/edital.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Edital } from '../models/edital';
+
+@Injectable({ providedIn: 'root' })
+export class EditalService {
+  private apiUrl = '/api/editais';
+
+  constructor(private http: HttpClient) {}
+
+  list(): Observable<Edital[]> {
+    return this.http.get<Edital[]>(this.apiUrl);
+  }
+
+  get(id: number): Observable<Edital> {
+    return this.http.get<Edital>(`${this.apiUrl}/${id}`);
+  }
+
+  create(edital: Edital): Observable<Edital> {
+    return this.http.post<Edital>(this.apiUrl, edital);
+  }
+
+  update(id: number, edital: Edital): Observable<Edital> {
+    return this.http.put<Edital>(`${this.apiUrl}/${id}`, edital);
+  }
+
+  delete(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/${id}`);
+  }
+}


### PR DESCRIPTION
## Summary
- add `Edital` interface
- provide HTTP client in configuration
- create service and standalone component for listing editais
- wire the new component in the router
- mark `AppComponent` as standalone

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877d83f62388322861e30746f4b11d5